### PR TITLE
enabling send_mail to return response to client

### DIFF
--- a/sso_handler.php
+++ b/sso_handler.php
@@ -189,12 +189,13 @@ class SSOHandler
     $curl_request = curl_init();
     curl_setopt($curl_request, CURLOPT_URL, "http://gymkhana.iitb.ac.in/sso/user/api/user/send_mail/");
     curl_setopt($curl_request, CURLOPT_HTTPHEADER, array('Content-Type: application/json' , 'Authorization: Bearer '.$access_token));
-    curl_setopt($curl_request, CURLOPT_RETURNTRANSFER, false);
+    curl_setopt($curl_request, CURLOPT_RETURNTRANSFER, true);
 
     $email_data = array('subject' => $subject, 'message' => $message, 'reply_to' => $reply_to);
     curl_setopt($curl_request, CURLOPT_POSTFIELDS, json_encode($email_data));
-    curl_exec($curl_request);
+    $response = curl_exec($curl_request);
     curl_close ($curl_request);
+    return $this->decode_json_response($response);
   }
 }
 ?>


### PR DESCRIPTION
send_mail API returns Message-ID in response now. 
Also keeping CURLOPT_RETURNTRANSFER to false lead to unwanted behavior as curl_exec dumps the output instead of returning it to some string.
